### PR TITLE
Add multi-workspace support

### DIFF
--- a/NowPlayin/NowPlayin/Models/Workspace.swift
+++ b/NowPlayin/NowPlayin/Models/Workspace.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct Workspace: Identifiable, Codable, Equatable {
+    let id: String       // Slack team ID (T12345678)
+    let name: String     // Display name (Acme Corp)
+
+    var keychainAccount: String { "nowplayin-token-\(id)" }
+}

--- a/NowPlayin/NowPlayin/ViewModels/NowPlayinViewModel.swift
+++ b/NowPlayin/NowPlayin/ViewModels/NowPlayinViewModel.swift
@@ -6,7 +6,12 @@ final class NowPlayinViewModel {
     var isSyncing = false
     var currentTrack: Track?
     var statusMessage = ""
-    var hasToken: Bool = false
+
+    // Multi-workspace support
+    var workspaces: [Workspace] = []
+    var workspaceStatuses: [String: String] = [:]  // workspace.id -> error message
+
+    var hasWorkspaces: Bool { !workspaces.isEmpty }
 
     // Settings stored in UserDefaults
     var pollingInterval: Double {
@@ -33,26 +38,82 @@ final class NowPlayinViewModel {
     private var lastStatusText: String?
     private var hasSetStatus = false
     private var shouldClearOnExit = true
-    private var cachedToken: String?
+
+    private static let workspacesKey = "workspaces"
 
     init() {
         if UserDefaults.standard.object(forKey: "pollingInterval") == nil {
             UserDefaults.standard.set(10.0, forKey: "pollingInterval")
         }
-        refreshTokenStatus()
+        loadWorkspaces()
+        migrateLegacyTokenIfNeeded()
     }
 
-    func refreshTokenStatus() {
-        cachedToken = KeychainService.loadToken()
-        hasToken = cachedToken != nil
+    // MARK: - Workspace Management
+
+    func loadWorkspaces() {
+        guard let data = UserDefaults.standard.data(forKey: Self.workspacesKey),
+              let decoded = try? JSONDecoder().decode([Workspace].self, from: data) else {
+            workspaces = []
+            return
+        }
+        workspaces = decoded
     }
+
+    func saveWorkspaces() {
+        guard let data = try? JSONEncoder().encode(workspaces) else { return }
+        UserDefaults.standard.set(data, forKey: Self.workspacesKey)
+    }
+
+    func addWorkspace(token: String) async throws -> Workspace {
+        let info = try await SlackService.getWorkspaceInfo(token: token)
+        let workspace = Workspace(id: info.teamId, name: info.teamName)
+
+        // Check if workspace already exists
+        if workspaces.contains(where: { $0.id == workspace.id }) {
+            throw WorkspaceError.alreadyExists
+        }
+
+        // Save token to keychain
+        guard KeychainService.saveToken(token, for: workspace) else {
+            throw WorkspaceError.keychainError
+        }
+
+        workspaces.append(workspace)
+        saveWorkspaces()
+        return workspace
+    }
+
+    func removeWorkspace(_ workspace: Workspace) {
+        KeychainService.deleteToken(for: workspace)
+        workspaces.removeAll { $0.id == workspace.id }
+        workspaceStatuses.removeValue(forKey: workspace.id)
+        saveWorkspaces()
+    }
+
+    private func migrateLegacyTokenIfNeeded() {
+        // Only migrate if we have no workspaces and a legacy token exists
+        guard workspaces.isEmpty,
+              let legacyToken = KeychainService.loadLegacyToken() else {
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                _ = try await addWorkspace(token: legacyToken)
+                KeychainService.deleteLegacyToken()
+            } catch {
+                // Keep legacy token if migration fails
+            }
+        }
+    }
+
+    // MARK: - Syncing
 
     func startSyncing() {
         guard !isSyncing else { return }
-
-        refreshTokenStatus()
-        guard let token = cachedToken else {
-            statusMessage = "No token configured"
+        guard hasWorkspaces else {
+            statusMessage = "No workspaces configured"
             return
         }
 
@@ -60,10 +121,11 @@ final class NowPlayinViewModel {
         hasSetStatus = false
         shouldClearOnExit = true
         lastStatusText = nil
+        workspaceStatuses = [:]
         statusMessage = "Starting..."
 
         pollingTask = Task { @MainActor in
-            await pollLoop(token: token)
+            await pollLoop()
         }
     }
 
@@ -72,9 +134,9 @@ final class NowPlayinViewModel {
         pollingTask = nil
         isSyncing = false
 
-        if clearStatus, let token = cachedToken, lastStatusText != nil {
+        if clearStatus && lastStatusText != nil {
             Task {
-                _ = try? await SlackService.clearStatus(token: token)
+                await clearAllWorkspaceStatuses()
             }
         }
 
@@ -85,23 +147,34 @@ final class NowPlayinViewModel {
     }
 
     func clearStatusOnQuit() {
-        guard shouldClearOnExit, let token = cachedToken, lastStatusText != nil else { return }
+        guard shouldClearOnExit, lastStatusText != nil, hasWorkspaces else { return }
 
         let semaphore = DispatchSemaphore(value: 0)
         Task {
-            _ = try? await SlackService.clearStatus(token: token)
+            await clearAllWorkspaceStatuses()
             semaphore.signal()
         }
         _ = semaphore.wait(timeout: .now() + 2)
     }
 
+    private func clearAllWorkspaceStatuses() async {
+        await withTaskGroup(of: Void.self) { group in
+            for workspace in workspaces {
+                group.addTask {
+                    guard let token = KeychainService.loadToken(for: workspace) else { return }
+                    _ = try? await SlackService.clearStatus(token: token)
+                }
+            }
+        }
+    }
+
     @MainActor
-    private func pollLoop(token: String) async {
+    private func pollLoop() async {
         while !Task.isCancelled {
             if !MusicService.isMusicAppRunning() {
                 if lastStatusText != nil {
                     statusMessage = "Music.app not running"
-                    _ = try? await SlackService.clearStatus(token: token)
+                    await clearAllWorkspaceStatuses()
                 }
                 stopSyncing(clearStatus: false)
                 return
@@ -123,36 +196,72 @@ final class NowPlayinViewModel {
                 newStatus = ""
             }
 
-            if hasSetStatus {
-                if let current = try? await SlackService.getStatus(token: token) {
-                    if !current.text.isEmpty && !SlackService.isOurStatus(current.emoji) {
-                        statusMessage = "Status changed externally"
-                        shouldClearOnExit = false
-                        stopSyncing(clearStatus: false)
-                        return
-                    }
-                }
-            }
-
             if newStatus != lastStatusText {
-                if !newStatus.isEmpty {
-                    statusMessage = "Updating status..."
-                    do {
-                        _ = try await SlackService.setStatus(token: token, text: newStatus)
-                        hasSetStatus = true
-                        statusMessage = ""
-                    } catch {
-                        statusMessage = "Error: \(error.localizedDescription)"
-                    }
-                } else if lastStatusText != nil {
-                    statusMessage = "Clearing status..."
-                    _ = try? await SlackService.clearStatus(token: token)
-                    statusMessage = ""
-                }
+                await updateAllWorkspaceStatuses(newStatus: newStatus)
                 lastStatusText = newStatus
             }
 
             try? await Task.sleep(for: .seconds(pollingInterval))
+        }
+    }
+
+    private func updateAllWorkspaceStatuses(newStatus: String) async {
+        if !newStatus.isEmpty {
+            statusMessage = "Updating status..."
+        } else if lastStatusText != nil {
+            statusMessage = "Clearing status..."
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for workspace in workspaces {
+                group.addTask {
+                    await self.updateWorkspaceStatus(workspace, newStatus: newStatus)
+                }
+            }
+        }
+
+        // Update status message based on results
+        let errorCount = workspaceStatuses.values.filter { !$0.isEmpty }.count
+        if errorCount == 0 {
+            statusMessage = ""
+            if !newStatus.isEmpty {
+                hasSetStatus = true
+            }
+        } else if errorCount == workspaces.count {
+            statusMessage = "All workspaces failed"
+        } else {
+            statusMessage = "\(errorCount) workspace(s) had errors"
+        }
+    }
+
+    @MainActor
+    private func updateWorkspaceStatus(_ workspace: Workspace, newStatus: String) async {
+        guard let token = KeychainService.loadToken(for: workspace) else {
+            workspaceStatuses[workspace.id] = "No token"
+            return
+        }
+
+        do {
+            if !newStatus.isEmpty {
+                _ = try await SlackService.setStatus(token: token, text: newStatus)
+            } else {
+                _ = try await SlackService.clearStatus(token: token)
+            }
+            workspaceStatuses[workspace.id] = ""
+        } catch {
+            workspaceStatuses[workspace.id] = error.localizedDescription
+        }
+    }
+}
+
+enum WorkspaceError: Error, LocalizedError {
+    case alreadyExists
+    case keychainError
+
+    var errorDescription: String? {
+        switch self {
+        case .alreadyExists: return "Workspace already added"
+        case .keychainError: return "Failed to save token"
         }
     }
 }

--- a/NowPlayin/NowPlayin/Views/MenuBarView.swift
+++ b/NowPlayin/NowPlayin/Views/MenuBarView.swift
@@ -50,7 +50,7 @@ struct MenuBarView: View {
                     systemImage: viewModel.isSyncing ? "stop.fill" : "play.fill"
                 )
             }
-            .disabled(!viewModel.hasToken && !viewModel.isSyncing)
+            .disabled(!viewModel.hasWorkspaces && !viewModel.isSyncing)
 
             Divider()
 

--- a/NowPlayin/NowPlayin/Views/PreferencesView.swift
+++ b/NowPlayin/NowPlayin/Views/PreferencesView.swift
@@ -3,46 +3,71 @@ import SwiftUI
 struct PreferencesView: View {
     @Bindable var viewModel: NowPlayinViewModel
 
+    @State private var isAddingWorkspace = false
     @State private var tokenInput = ""
-    @State private var tokenSaveMessage = ""
+    @State private var addWorkspaceMessage = ""
+    @State private var isAddingToken = false
     @State private var launchAtLogin = false
+
+    private let oauthURL = URL(string: "https://api.slack.com/apps")!
 
     var body: some View {
         Form {
-            Section("Slack Token") {
-                SecureField("Token (xoxp-...)", text: $tokenInput)
-                    .textFieldStyle(.roundedBorder)
-
-                HStack {
-                    Button("Save Token") {
-                        saveToken()
-                    }
-                    .disabled(tokenInput.isEmpty)
-
-                    if viewModel.hasToken {
-                        Button("Delete Token", role: .destructive) {
-                            deleteToken()
-                        }
-                    }
-
-                    Spacer()
-
-                    if !tokenSaveMessage.isEmpty {
-                        Text(tokenSaveMessage)
-                            .font(.caption)
-                            .foregroundStyle(tokenSaveMessage.contains("saved") ? .green : .red)
-                    }
-                }
-
-                if viewModel.hasToken {
-                    Label("Token configured", systemImage: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
+            Section("Slack Workspaces") {
+                if viewModel.workspaces.isEmpty {
+                    Text("No workspaces configured")
+                        .foregroundStyle(.secondary)
                         .font(.caption)
                 } else {
-                    Label("No token configured", systemImage: "exclamationmark.circle.fill")
-                        .foregroundStyle(.orange)
-                        .font(.caption)
+                    ForEach(viewModel.workspaces) { workspace in
+                        WorkspaceRow(
+                            workspace: workspace,
+                            errorMessage: viewModel.workspaceStatuses[workspace.id],
+                            onRemove: {
+                                viewModel.removeWorkspace(workspace)
+                            }
+                        )
+                    }
                 }
+
+                if isAddingWorkspace {
+                    VStack(alignment: .leading, spacing: 8) {
+                        SecureField("Paste token (xoxp-...)", text: $tokenInput)
+                            .textFieldStyle(.roundedBorder)
+
+                        HStack {
+                            Button("Add") {
+                                addWorkspace()
+                            }
+                            .disabled(tokenInput.isEmpty || isAddingToken)
+
+                            Button("Cancel") {
+                                isAddingWorkspace = false
+                                tokenInput = ""
+                                addWorkspaceMessage = ""
+                            }
+
+                            if isAddingToken {
+                                ProgressView()
+                                    .scaleEffect(0.5)
+                            }
+
+                            if !addWorkspaceMessage.isEmpty {
+                                Text(addWorkspaceMessage)
+                                    .font(.caption)
+                                    .foregroundStyle(addWorkspaceMessage.contains("Added") ? .green : .red)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                } else {
+                    Button("Add Workspace...") {
+                        isAddingWorkspace = true
+                    }
+                }
+
+                Link("Get token from Slack", destination: oauthURL)
+                    .font(.caption)
             }
 
             Section("Sync Settings") {
@@ -77,21 +102,58 @@ struct PreferencesView: View {
         }
     }
 
-    private func saveToken() {
+    private func addWorkspace() {
         guard !tokenInput.isEmpty else { return }
-        if KeychainService.saveToken(tokenInput) {
-            tokenSaveMessage = "Token saved in Keychain"
-            tokenInput = ""
-            viewModel.refreshTokenStatus()
-        } else {
-            tokenSaveMessage = "Failed to save token"
+        isAddingToken = true
+        addWorkspaceMessage = ""
+
+        Task { @MainActor in
+            do {
+                let workspace = try await viewModel.addWorkspace(token: tokenInput)
+                addWorkspaceMessage = "Added \(workspace.name)"
+                tokenInput = ""
+                isAddingWorkspace = false
+            } catch {
+                addWorkspaceMessage = error.localizedDescription
+            }
+            isAddingToken = false
         }
     }
+}
 
-    private func deleteToken() {
-        KeychainService.deleteToken()
-        tokenSaveMessage = "Token deleted"
-        viewModel.refreshTokenStatus()
+struct WorkspaceRow: View {
+    let workspace: Workspace
+    let errorMessage: String?
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(workspace.name)
+                    .font(.body)
+                Text(workspace.id)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if let error = errorMessage, !error.isEmpty {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .help(error)
+            } else {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+
+            Button(role: .destructive) {
+                onRemove()
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+        }
     }
 }
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -17,6 +17,24 @@ All data is stored locally on your Mac:
 
 No data is stored on external servers controlled by the developer.
 
+## Slack Permissions
+
+When you authorize NowPlayin, Slack shows these permissions:
+
+| Slack says | What we actually do |
+|------------|---------------------|
+| "View profile details about people in your workspace" | **We don't.** This permission comes from the `users.profile:read` scope, but we only read *your own* status to detect manual changes. We never access other users' profiles. |
+| "View information about your identity" | We use this only to verify your token works. |
+| "Edit your profile information and status" | **Yes, this is something we do.** We update your status with the currently playing track. We don't modify any other profile information. |
+
+### Why these permissions?
+
+Slack's `users.profile:read` and `users.profile:write` scopes are broad by design. We request the minimum scopes needed to:
+1. Read your current status (to avoid overwriting manual changes)
+2. Write your status (to show what's playing)
+
+We cannot request narrower permissions — Slack doesn't offer status-only scopes.
+
 ## Network Communication
 
 The app communicates only with:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sync your Slack status with the currently playing track in Music.app.
 
 1. Visit https://slack.nowplayin.workers.dev
 2. Click **Add to Slack**
-3. Authorize for your workspace
+3. Authorize for your workspace (see [Slack Permissions](PRIVACY.md#slack-permissions) for what we do and don't access)
 4. Copy the token displayed (starts with `xoxp-`)
 
 ## Install


### PR DESCRIPTION
## Summary

- Sync Music.app status to multiple Slack workspaces simultaneously
- Add workspace management UI in Preferences (add/remove workspaces)
- Parallel status updates across all configured workspaces
- Auto-migrate existing single-token setups to new workspace format
- Document Slack API permissions used by the app

## Test plan

- [x] Add first workspace via token - verify token saved and name displayed
- [x] Add second workspace - verify both appear in list
- [x] Play music - verify status updates in both workspaces
- [x] Revoke one workspace's token in Slack - verify other continues working
- [x] Remove a workspace - verify token deleted and removed from list
- [x] Test migration: use app with existing token, verify auto-migration to workspace